### PR TITLE
Disable the agencies lineup in footer

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -15,9 +15,9 @@
       <p>The DOE Office of Science is the single largest supporter of basic research in the physical sciences in the United States and is working to address some of the most pressing challenges of our time.</p>
     </div>
 
-
-    <div class="rubin-footer-partners">
+    <!-- Disabled because Discourse cannot load the uploaded image. -->
+    <!-- <div class="rubin-footer-partners">
       <img src="{{theme-setting "theme_uploads.agencies"}}">
-    </div>
+    </div> -->
   </footer>
 </script>


### PR DESCRIPTION
Discourse is having trouble loading the uploaded image asset, so we need
to disable this graphic in the meantime.